### PR TITLE
Updated structs for new role scheme in Discord.

### DIFF
--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -15,16 +15,16 @@ pub struct Config {
     pub cmd_prefix: String,
     /// The Discord role ID for normal members.
     pub member_role: u64,
-    /// The Discord role ID for keynote members.
-    pub keynote_role: u64,
-    /// The number of hours voting will be open when a new vote is created. Default is 24.
-    pub vote_hours: u32,
+    /// The Discord role ID for casual players.
+    pub casual_role: u64,
+    /// The Discord role ID for competitive players.
+    pub comp_role: u64,
+    /// The number of minutes voting will be open when a new vote is created. Default is 1440 (24h).
+    pub vote_minutes: u64,
     /// The Discord channel ID in which votes will be announced.
     pub channel_announce: u64,
-    /// The Discord channel ID in which normal members can vote.
+    /// The Discord channel ID in which users can vote.
     pub channel_vote: u64,
-    /// The Discord channel ID in which keynote members can vote.
-    pub channel_keynote: u64,
     /// The permissions section.
     pub permissions: BTreeMap<String, Vec<String>>,
 }
@@ -34,11 +34,11 @@ impl Default for Config {
         Config {
             cmd_prefix: "!".into(),
             member_role: 0,
-            keynote_role: 1,
-            vote_hours: 24,
+            casual_role: 0,
+            comp_role: 0,
+            vote_minutes: 1440,
             channel_announce: 0,
             channel_vote: 0,
-            channel_keynote: 1, // this needs to be different from channel_vote
             permissions: Default::default(),
         }
     }

--- a/src/model/vote.rs
+++ b/src/model/vote.rs
@@ -3,38 +3,32 @@
 pub struct Vote {
     /// Vote ID.
     pub id: u64,
-    /// Number of yes votes.
-    pub yes: u64,
-    /// Number of no votes.
-    pub no: u64,
+    /// Number of yes votes from users with the Casual role.
+    pub casual_yes: u64,
+    /// Number of no votes from users with the Casual role.
+    pub casual_no: u64,
+    /// Number of yes votes from users with the Competitive role.
+    pub comp_yes: u64,
+    /// Number of no votes from users with the Competitive role.
+    pub comp_no: u64,
     /// The time at which voting closes and the results are final.
     pub end_time: u64,
 }
 
 impl Vote {
     /// Creates a new vote with the ID `id`, which ends at `end_time`
-    fn new(id: u64, end_time: u64) -> Self {
+    pub fn new(id: u64, end_time: u64) -> Self {
         Vote {
             id,
-            yes: 0,
-            no: 0,
-            end_time
+            casual_yes: 0,
+            casual_no: 0,
+            comp_yes: 0,
+            comp_no: 0,
+            end_time,
         }
     }
-    /// Increments the counter for yes votes.
-    fn add_yes(&mut self) {
-        self.yes = self.yes + 1;
-    }
-    /// Decrements the coutner for yes votes.
-    fn rm_yes(&mut self) {
-        self.yes = self.yes - 1;
-    }
-    /// Increments the counter for no votes.
-    fn add_no(&mut self) {
-        self.no = self.no + 1;
-    }
-    /// Decrements the counter for no votes.
-    fn rm_no(&mut self) {
-        self.no = self.no - 1;
+    /// Gets the total yes and no votes, regardless of casual/comp.
+    pub fn total(&self) -> (u64, u64) {
+        (self.casual_yes + self.comp_yes, self.casual_no + self.comp_no)
     }
 }


### PR DESCRIPTION
We've decided to drop the previous "normal user" and "keynote" scheme in favor of distinguishing votes between primarily casual and primarily competitive players.

This is for the purpose of gathering statistics on what the casual community generally wants, as well as the competitive community. This will help us come to compromises in the case of disagreements between the 2 camps. 

Also, since the purpose of balance.tf is to persuade the TF team to make changes to the game, it'd likely ease their mind about proposed changes if they knew for sure that we're not exclusively polling people who agree with our ideas.

This is NOT for the purpose of organizing one group's opinions in one place to make it easier to ignore them. In fact, it is quite the opposite. Without this system, we could easily have an overwhelming majority of either side voting without realizing it, resulting in one side being under represented.